### PR TITLE
Fix code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/camachoo18/express-figlet#readme",
   "dependencies": {
     "express": "^4.21.1",
-    "shell-quote": "^1.8.1"
+    "shell-quote": "^1.8.1",
+    "express-rate-limit": "^7.4.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 const express = require("express")
 const { exec } = require('child_process');
 const { quote } = require('shell-quote');
-
+const RateLimit = require('express-rate-limit');
 
 
 //const comando = "figlet hola mundo";
@@ -10,6 +10,14 @@ const port = 3000
 
 
 app.use(express.static("public"))
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
+app.use(limiter);
 
 app.get("/", (req, res) =>{
     exec (comando, (error, stdout, stderr)=>{


### PR DESCRIPTION
Fixes [https://github.com/camachoo18/express-figlet/security/code-scanning/4](https://github.com/camachoo18/express-figlet/security/code-scanning/4)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will limit the number of requests a client can make to the server within a specified time window, thereby mitigating the risk of DoS attacks.

1. Install the `express-rate-limit` package.
2. Set up a rate limiter with a reasonable configuration (e.g., 100 requests per 15 minutes).
3. Apply the rate limiter to the routes that execute system commands.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
